### PR TITLE
reorg ci into multiple jobs; deploy for 1 py version

### DIFF
--- a/.github/workflows/HGDL-CI.yml
+++ b/.github/workflows/HGDL-CI.yml
@@ -45,6 +45,15 @@ jobs:
           path_to_write_report: ./coverage/codecov_report.txt
           verbose: true
 
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
       - name: Setup deploy
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         run: |

--- a/.github/workflows/HGDL-CI.yml
+++ b/.github/workflows/HGDL-CI.yml
@@ -46,7 +46,7 @@ jobs:
           verbose: true
 
   deploy:
-    needs: build
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python 3.8


### PR DESCRIPTION
Separate the single `test` job into a `test` job and a `deploy` job (which depends on a successful `test` job execution).
Deploys using python 3.8.

Alternatively, this could be fixed by adding an extra condition (`matrix.python-version`) to the deploy, publish, and release steps:

```
if: |
  github.event_name == 'push' && 
  startsWith(github.ref, 'refs/tags') &&
  matrix.python-version == '3.8'
```